### PR TITLE
Change action to be tag based

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -2,13 +2,12 @@ name: .NET
 
 on:
   push:
-    branches: [ "master" ]
+    tags:
+    - 'v[0-9]+\.[0-9]+'
 
 jobs:
   build:
-
     runs-on: windows-latest
-
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET
@@ -19,8 +18,6 @@ jobs:
       run: dotnet restore
     - name: Find and Replace
       run: (Get-Content ACCStatsUploader/SheetsAPIController.cs) -replace 'asf = "replace_me"', 'asf = "${{ secrets.CLIENT_SECRET_LESS_PERMISSIONS }}"' | Out-File -encoding UTF8 SheetsAPIController.cs
-    - name: prit 
-      run: type SheetsAPIController.cs
     - name: Publish
       run: dotnet publish -c release -o bin\publish
     - name: Archive Release
@@ -32,7 +29,7 @@ jobs:
     - uses: "marvinpinto/action-automatic-releases@latest"
       with:
         repo_token: "${{ secrets.GITHUB_TOKEN }}"
-        automatic_release_tag: "latest"
+        automatic_release_tag: ${{ github.ref_name }}
         prerelease: false
-        title: "Development Build"
-        files: "release.zip"
+        title: "${{ github.ref_name }}"
+        files: "${{ github.ref_name }}-release.zip"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build:
+    name: pr-check
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,20 @@
+name: pr
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v2
+      with:
+        dotnet-version: 6.0.x
+    - name: Restore dependencies
+      run: dotnet restore
+    - name: Publish
+      run: dotnet publish -c release -o bin\publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: .NET
+name: release
 
 on:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build:
+    name: release-build
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Changed some things around in the release job to make it only run when pushing a version tag. Also include the version tag in the release title.