### PR TITLE
Fix drivethrough PitIn event

### DIFF
--- a/ACCStatsUploader/Events/PitOutEvent.cs
+++ b/ACCStatsUploader/Events/PitOutEvent.cs
@@ -16,7 +16,6 @@ namespace ACCStatsUploader {
 
         public PitOutEvent(Graphics graphicsInfo, Physics physicsInfo) {
             sessionType = SessionTypeConverter.toString(graphicsInfo.session);
-            pitBoxOutClockTime = graphicsInfo.Clock;
             tyreSet = graphicsInfo.currentTyreSet;
 
             initialTyrePressures = new Wheels(
@@ -25,6 +24,10 @@ namespace ACCStatsUploader {
                 physicsInfo.wheelsPressure[2],
                 physicsInfo.wheelsPressure[3]
             );
+        }
+
+        public void setPitBoxOut(Graphics graphicsInfo) {
+            pitBoxOutClockTime = graphicsInfo.Clock;
         }
 
         public void setPitOut(Graphics graphicsInfo, StaticInfo staticInfo) {

--- a/ACCStatsUploader/SharedMemoryReading/Graphics.cs
+++ b/ACCStatsUploader/SharedMemoryReading/Graphics.cs
@@ -49,34 +49,34 @@ namespace ACCStatsUploader {
         ACC_THUNDERSTORM = 5
     };
 
-    public enum PenaltyShortcut {
-        None,
-        DriveThrough_Cutting,
-        StopAndGo_10_Cutting,
-        StopAndGo_20_Cutting,
-        StopAndGo_30_Cutting,
-        Disqualified_Cutting,
-        RemoveBestLaptime_Cutting,
+    public enum ACC_PENALTY_TYPE {
+        None = 0,
+        DriveThrough_Cutting = 1,
+        StopAndGo_10_Cutting = 2,
+        StopAndGo_20_Cutting = 3,
+        StopAndGo_30_Cutting = 4,
+        Disqualified_Cutting = 5,
+        RemoveBestLaptime_Cutting = 6,
 
-        DriveThrough_PitSpeeding,
-        StopAndGo_10_PitSpeeding,
-        StopAndGo_20_PitSpeeding,
-        StopAndGo_30_PitSpeeding,
-        Disqualified_PitSpeeding,
-        RemoveBestLaptime_PitSpeeding,
+        DriveThrough_PitSpeeding = 7,
+        StopAndGo_10_PitSpeeding = 8,
+        StopAndGo_20_PitSpeeding = 9,
+        StopAndGo_30_PitSpeeding = 10,
+        Disqualified_PitSpeeding = 11,
+        RemoveBestLaptime_PitSpeeding = 12,
 
-        Disqualified_IgnoredMandatoryPit,
+        Disqualified_IgnoredMandatoryPit = 13,
 
-        PostRaceTime,
-        Disqualified_Trolling,
-        Disqualified_PitEntry,
-        Disqualified_PitExit,
-        Disqualified_WrongWay,
+        PostRaceTime = 14,
+        Disqualified_Trolling = 15,
+        Disqualified_PitEntry = 16,
+        Disqualified_PitExit = 17,
+        Disqualified_WrongWay = 18,
 
-        DriveThrough_IgnoredDriverStint,
-        Disqualified_IgnoredDriverStint,
+        DriveThrough_IgnoredDriverStint = 19,
+        Disqualified_IgnoredDriverStint = 20,
 
-        Disqualified_ExceededDriverStintLimit,
+        Disqualified_ExceededDriverStintLimit = 21,
     };
 
     public class GraphicsEventArgs : EventArgs {
@@ -126,7 +126,7 @@ namespace ACCStatsUploader {
         public int playerCarID;
         public float penaltyTime;
         public ACC_FLAG_TYPE flag;
-        public int penalty;
+        public ACC_PENALTY_TYPE penalty;
         public int idealLineOn;
         public int isInPitLane;
         public float surfaceGrip;

--- a/ACCStatsUploader/Sheets/PitstopSheet.cs
+++ b/ACCStatsUploader/Sheets/PitstopSheet.cs
@@ -73,6 +73,8 @@ namespace ACCStatsUploader {
         public async Task insertPitInEvent(PitInEvent pitInEvent) {
             var pitEventRequest = gsController.createSheetRequest();
 
+            var tyreSet = pitInEvent.tyreSet == 0 ? "W" : pitInEvent.tyreSet.ToString();
+
             pitEventRequest.addRequest(this.appendRow(new Cells {
                 new Cell { value = pitInEvent.sessionType },
                 new Cell { value = pitInEvent.type },
@@ -84,7 +86,7 @@ namespace ACCStatsUploader {
                 new Cell { value = "" },
                 new Cell { value = pitInEvent.driverName },
                 new Cell { value = pitInEvent.driveTimeLeft },
-                new Cell { value = pitInEvent.tyreSet }
+                new Cell { value = tyreSet }
             }));
 
             await pitEventRequest.execute();
@@ -92,6 +94,8 @@ namespace ACCStatsUploader {
 
         public async Task insertPitOutEvent(PitOutEvent pitOutEvent) {
             var pitEventRequest = gsController.createSheetRequest();
+
+            var tyreSet = pitOutEvent.tyreSet == 0 ? "W" : pitOutEvent.tyreSet.ToString();
 
             pitEventRequest.addRequest(this.appendRow(new Cells {
                 new Cell { value = pitOutEvent.sessionType },
@@ -104,7 +108,7 @@ namespace ACCStatsUploader {
                 new Cell { value = pitOutEvent.pitBoxOutClockTime },
                 new Cell { value = pitOutEvent.driverName },
                 new Cell { value = "" },
-                new Cell { value = pitOutEvent.tyreSet },
+                new Cell { value = tyreSet },
                 new Cell { value = pitOutEvent.initialTyrePressures.fl },
                 new Cell { value = pitOutEvent.initialTyrePressures.fr },
                 new Cell { value = pitOutEvent.initialTyrePressures.rl },

--- a/ACCStatsUploader/TelemetryController.cs
+++ b/ACCStatsUploader/TelemetryController.cs
@@ -358,9 +358,10 @@ namespace ACCStatsUploader {
                             if (currentState == TRACK_STATE.ON_TRACK) {
                                 pitInEvent = new PitInEvent(unwrappedGraphics, unwrappedStaticInfo);
                                 lapInfo.isInLap = true;
-                            } else {
+                            } else if (currentState == TRACK_STATE.PIT_BOX) {
                                 // pit box out event?
                                 pitOutEvent = new PitOutEvent(unwrappedGraphics, unwrappedPhysics);
+                                pitOutEvent.setPitBoxOut(unwrappedGraphics);
                             }
 
                             break;

--- a/ACCStatsUploader/TelemetryController.cs
+++ b/ACCStatsUploader/TelemetryController.cs
@@ -339,6 +339,13 @@ namespace ACCStatsUploader {
                             if (currentState == TRACK_STATE.PIT_LANE) {
                                 // put out event
                                 lapInfo.isOutLap = true;
+
+                                // if we just drove through the pit lane
+                                if (pitInEvent != null) {
+                                    await sheetController.insertPitInEvent(pitInEvent);
+                                    pitInEvent = null;
+                                }
+
                                 if (pitOutEvent == null) {
                                     pitOutEvent = new PitOutEvent(unwrappedGraphics, unwrappedPhysics);
                                 }


### PR DESCRIPTION
Make sure we send the existing PitIn event before the PitOut event, in case we're not stopping in the pit box.